### PR TITLE
Add authentication toggle

### DIFF
--- a/wmt-web/app/authentication.js
+++ b/wmt-web/app/authentication.js
@@ -7,10 +7,11 @@ const getRoles = require('./services/data/get-user-roles')
 var SamlStrategy = require('passport-saml').Strategy
 
 module.exports = function (app) {
+  if (!config.AUTHENTICATION_ENABLED) return
+
   passport.serializeUser(function (user, done) {
     var email = user['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name']
     var displayName = user['http://schemas.microsoft.com/identity/claims/displayname']
-    console.log(user)
     getRoles(email).then(function (roles) {
       done(null, {
         name: displayName,

--- a/wmt-web/app/authorisation.js
+++ b/wmt-web/app/authorisation.js
@@ -1,3 +1,4 @@
+const config = require('../config')
 
 function isAuthenticated (req) {
   if (!req.user) {
@@ -8,6 +9,7 @@ function isAuthenticated (req) {
 }
 
 function isAdmin (req) {
+  if (!config.AUTHENTICATION_ENABLED) return
   isAuthenticated(req)
 
   if (!req.user.user_roles.includes('admin')) {

--- a/wmt-web/config.js
+++ b/wmt-web/config.js
@@ -5,5 +5,6 @@ module.exports = {
   DATABASE_USERNAME: process.env.WMT_DB_USERNAME || 'wmt',
   DATABASE_PASSWORD: process.env.WMT_DB_PASSWORD || 'wmt',
 
+  AUTHENTICATION_ENABLED: false,
   SESSION_SECRET: 'secret'
 }


### PR DESCRIPTION
Add the AUTHENTICATION_ENABLED configuration option. Set this to false by
default. This means that passport will not be initialised and every user will be
assumed to be an admin.