### PR TITLE
Add error templates

### DIFF
--- a/wmt-web/app/views/includes/error-404.html
+++ b/wmt-web/app/views/includes/error-404.html
@@ -1,0 +1,18 @@
+{% extends "includes/layout.html" %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">This page cannot be found</h1>
+      <p>You can <a href="/">return to the home page</a></p>
+
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/wmt-web/app/views/includes/error.html
+++ b/wmt-web/app/views/includes/error.html
@@ -1,0 +1,18 @@
+{% extends "includes/layout.html" %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">An Error has occurred</h1>
+      <p>{{ error }}</p>
+
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}


### PR DESCRIPTION
In order for meaningful errors to be displayed to the user when using the WMT
HTML templates are required to parse the errors.